### PR TITLE
(PDB-2678) Initial checkin of the caching proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/cache

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ with storing the crates themselves, not the index.
 ## Usage
 
 The entire application is a single clojure file, launched via `lein
-crate-proxy`. By default the proxy will launch on port 8080 and cache
+crate-proxy`. By default the proxy will launch on port 8888 and cache
 the crates in the `proxy-cache` directory, wherever it was
 launched. To override the port and the cache directory, use a command
 like: `CACHE_ROOT="/full/path/to/dir" CRATE_PROXY_PORT=9090 lein crate-proxy`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-TBD - this is a placeholder to init the repo
+# crates-caching-proxy
+
+A Clojure-based caching proxy for Cargo crates downloaded from
+[crates.io](https://crates.io). The primary intent of the application
+is to have a functioning build while the crates.io site is down. Note
+that there are two pieces to downloading crates, the first is the
+[create-io.index](https://github.com/rust-lang/crates.io-index) and
+the second is the packages themselves. This project is only concerned
+with storing the crates themselves, not the index.
+
+## Usage
+
+The entire application is a single clojure file, launched via `lein
+crate-proxy`. By default the proxy will launch on port 8080 and cache
+the crates in the `proxy-cache` directory, wherever it was
+launched. To override the port and the cache directory, use a command
+like: `CACHE_ROOT="/full/path/to/dir" CRATE_PROXY_PORT=9090 lein crate-proxy`.
+
+## Maintenance
+
+Maintainers: Ryan Senior <ryan.senior@puppet.com>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,37 @@ the crates in the `proxy-cache` directory, wherever it was
 launched. To override the port and the cache directory, use a command
 like: `CACHE_ROOT="/full/path/to/dir" CRATE_PROXY_PORT=9090 lein crate-proxy`.
 
+To point cargo at your local proxy, first clone the
+[create-io.index](https://github.com/rust-lang/crates.io-index). Change
+the config.json in the root of the repository to indicate the local
+proxy:
+
+```
+{
+  "dl": "http://localhost:8888/api/v1/crates",
+  "api": "http://localhost:8888/"
+}
+```
+
+Commit that change to the local crates-io.index repository. In the
+root directory of the cargo project you're wanting to build create a
+`.cargo/config` file that points to the local create-io.index:
+
+```
+[registry]
+index = "file:///local/path/to/creates.io-index"
+```
+
+When running `cargo build`, you will see `Updating registry...` which
+will point to the new repostory location. The crates will be
+downloaded to the `CACHE_ROOT` directory, subqequent cargo runs will
+use the local cached copy.
+
+It's important to note that cargo won't attempt to download crates
+that already exist in the `~/.cargo/registry`. Make sure to clear that
+directory so that cargo will go fetch the depdencies and ensure the
+proxy is working.
+
 ## Maintenance
 
 Maintainers: Ryan Senior <ryan.senior@puppet.com>

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,15 @@
+(defproject puppetlabs/crates-caching-proxy "0.1.0-SNAPSHOT"
+  :description "Clojure web application that proxies and caches Rust Cargo crates from crates.io"
+  :url "http://github.com/puppetlabs/crates-caching-proxy"
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [ring "1.5.0-RC1"]
+                 [puppetlabs/http-client "0.5.0"]
+                 [puppetlabs/comidi "0.3.1"]
+                 [puppetlabs/kitchensink "1.3.1"]
+                 [org.clojure/tools.logging "0.3.1"]
+                 [slingshot "0.12.2"]
+                 [ch.qos.logback/logback-classic "1.1.7"]
+                 [environ "1.0.3"]]
+  :profiles {:dev {:dependencies [[ring/ring-mock "0.3.0"]]}}
+  :aliases {"crate-proxy" ["trampoline" "run" "-m" "crates-caching-proxy.core"]})
+

--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,3 @@
                  [environ "1.0.3"]]
   :profiles {:dev {:dependencies [[ring/ring-mock "0.3.0"]]}}
   :aliases {"crate-proxy" ["trampoline" "run" "-m" "crates-caching-proxy.core"]})
-

--- a/project.clj
+++ b/project.clj
@@ -11,4 +11,4 @@
                  [ch.qos.logback/logback-classic "1.1.7"]
                  [environ "1.0.3"]]
   :profiles {:dev {:dependencies [[ring/ring-mock "0.3.0"]]}}
-  :aliases {"crate-proxy" ["trampoline" "run" "-m" "crates-caching-proxy.core"]})
+  :aliases {"crate-proxy" ["trampoline" "run" "-m" "puppetlabs.crates-caching-proxy.core"]})

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,6 @@
                  [puppetlabs/kitchensink "1.3.1"]
                  [org.clojure/tools.logging "0.3.1"]
                  [slingshot "0.12.2"]
-                 [ch.qos.logback/logback-classic "1.1.7"]
-                 [environ "1.0.3"]]
+                 [ch.qos.logback/logback-classic "1.1.7"]]
   :profiles {:dev {:dependencies [[ring/ring-mock "0.3.0"]]}}
   :aliases {"crate-proxy" ["trampoline" "run" "-m" "puppetlabs.crates-caching-proxy.core"]})

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,0 +1,24 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%thread] [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="F1" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/caching-crate-proxy.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/caching-crate-proxy-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="F1"/>
+    </root>
+</configuration>

--- a/src/puppetlabs/crates_caching_proxy/core.clj
+++ b/src/puppetlabs/crates_caching_proxy/core.clj
@@ -1,0 +1,100 @@
+(ns puppetlabs.crates-caching-proxy.core
+  (:import [java.nio.file Files Paths StandardCopyOption Path CopyOption]
+           [java.nio.file.attribute FileAttribute])
+  (:require [ring.adapter.jetty :as rj]
+            [clojure.string :as str]
+            [puppetlabs.http.client.sync :as hsync]
+            [ring.util.request :as rreq]
+            [ring.util.response :as rresp]
+            [puppetlabs.comidi :as cmdi]
+            [clojure.tools.logging :as log]
+            [slingshot.slingshot :refer [throw+ try+]]
+            [environ.core :as environ]))
+
+(def cache-root (delay (get environ/env :cache-root "proxy-cache")))
+
+(def port (delay (Long/parseLong (get environ/env :crate-proxy-port "8080"))))
+
+(def crates-io-api-root "/api/v1/crates")
+
+(def crates-io-url (str "https://crates.io" crates-io-api-root))
+
+(defn ^Path path-get [^String s & more-strings]
+  (Paths/get s (into-array String more-strings)))
+
+(defn ^Path create-temp-file [^Path dir prefix suffix]
+  (Files/createTempFile dir prefix suffix (into-array FileAttribute [])))
+
+(defn create-file-response [package version package-name]
+  (rresp/file-response (format "%s/%s/%s" package version package-name)
+                       {:root @cache-root
+                        :index-files? false
+                        :allow-symlinks? false}))
+
+(defn download-crate [package version]
+  
+  (let [package-url (format "%s/%s/%s/download" crates-io-url package version)
+        _ (log/infof "Downloading package using URL '%s'" package-url)
+        resp (hsync/get package-url)]
+
+    (log/debugf "Response received from URL '%s' was '%s' with a content length of"
+                package-url
+                (:status resp)
+                (get-in resp [:headers "content-length"]))
+
+    (if (= 200 (:status resp))
+      (:body resp)
+      (throw+ {:kind ::download-error
+               :status (:status resp)
+               :response-body (slurp (:body resp))}
+              (format "Error downloading package '%s'" package-url)))))
+
+(defn store-crate [package version package-name]
+  (let [crate-path (path-get @cache-root package version)
+        final-crate-path (path-get @cache-root package version package-name)]
+    (Files/createDirectories crate-path (into-array FileAttribute []))
+    (let [temp-file (create-temp-file crate-path package "crate")]
+      (with-open [input-stream (download-crate package version)]
+        (Files/copy input-stream temp-file (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING])))
+      (Files/move temp-file final-crate-path (into-array CopyOption [StandardCopyOption/ATOMIC_MOVE]))
+      (create-file-response package version package-name))))
+
+(defn find-crate [package version package-name]
+  (if-let [file-response (create-file-response package version package-name)]
+    (do
+      (log/infof "Found version '%s' of '%s' cached, returning cached version" version package-name)
+      file-response)
+    (do
+      (log/infof "Version '%s' of '%s' cached, not found locally, downloading it" version package-name)
+      (store-crate package version package-name))))
+
+(def cache-handler
+  (cmdi/routes->handler
+   (cmdi/context crates-io-api-root
+                 (cmdi/routes
+                  (cmdi/GET ["/" :package "/" :version "/download"] [package version]
+                            (rresp/redirect
+                             (format "%s/%s/%s/%s.crate" crates-io-api-root package version package)))
+                  (cmdi/GET ["/" :package-dir "/" :version "/" :package-name] [package-dir version package-name]
+                            (try+
+                             (find-crate package-dir version package-name)
+                             (catch [:kind ::download-error] {:keys [status response-body]}
+                               (log/errorf "Error occured while downloading version '%s' of '%s'. Status was '%s' with response '%s"
+                                           version package-name status response-body)
+                               {:status status
+                                :body (format (str "Downloading remote packaged failed."
+                                                   "Error from remote host was '%s%")
+                                              response-body)})
+                             (catch Exception e
+                               (log/errorf e "Error occured while downloading version '%s' of '%s'"
+                                           version package-name)
+                               {:status 500
+                                :body (.getMessage e)})))))))
+
+(defn -main []
+  (let [startup-log-str (format "Starting the caching proxy with '%s' as the proxy's cache directory, on port '%s'"
+                                @cache-root @port)]
+    (println startup-log-str)
+    (log/info startup-log-str))
+  (rj/run-jetty #'cache-handler {:port @port}))
+

--- a/src/puppetlabs/crates_caching_proxy/core.clj
+++ b/src/puppetlabs/crates_caching_proxy/core.clj
@@ -32,7 +32,6 @@
                         :allow-symlinks? false}))
 
 (defn download-crate [package version]
-  
   (let [package-url (format "%s/%s/%s/download" crates-io-url package version)
         _ (log/infof "Downloading package using URL '%s'" package-url)
         resp (hsync/get package-url)]
@@ -82,8 +81,8 @@
                                (log/errorf "Error occured while downloading version '%s' of '%s'. Status was '%s' with response '%s"
                                            version package-name status response-body)
                                {:status status
-                                :body (format (str "Downloading remote packaged failed."
-                                                   "Error from remote host was '%s%")
+                                :body (format (str "Downloading remote packaged failed. "
+                                                   "Error from remote host was '%s'")
                                               response-body)})
                              (catch Exception e
                                (log/errorf e "Error occured while downloading version '%s' of '%s'"

--- a/src/puppetlabs/crates_caching_proxy/core.clj
+++ b/src/puppetlabs/crates_caching_proxy/core.clj
@@ -13,7 +13,7 @@
 
 (def cache-root (delay (get environ/env :cache-root "proxy-cache")))
 
-(def port (delay (Long/parseLong (get environ/env :crate-proxy-port "8080"))))
+(def port (delay (Long/parseLong (get environ/env :crate-proxy-port "8888"))))
 
 (def crates-io-api-root "/api/v1/crates")
 

--- a/test/crates_caching_proxy/core_test.clj
+++ b/test/crates_caching_proxy/core_test.clj
@@ -1,7 +1,58 @@
 (ns crates-caching-proxy.core-test
+  (:import [java.nio.file Files Paths Path]
+           [java.nio.file.attribute FileAttribute]
+           [java.io ByteArrayInputStream])
   (:require [clojure.test :refer :all]
-            [crates-caching-proxy.core :refer :all]))
+            [puppetlabs.crates-caching-proxy.core :refer :all]
+            [ring.mock.request :as mock]
+            [clojure.java.io :as io]
+            [puppetlabs.http.client.sync :as hsync]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(defn str-bytes [s]
+  (.getBytes s "UTF-8"))
+
+(deftest test-download-redirect
+  (let [resp (cache-handler (mock/request :get "/api/v1/crates/hyper/0.8.0/download"))]
+    (is (= 302 (:status resp)))
+    (is (= "/api/v1/crates/hyper/0.8.0/hyper.crate"
+           (get-in resp [:headers "Location"])))
+    (is (= "" (:body resp)))))
+
+(deftest test-crate-storage
+  (let [temp-path (Files/createTempDirectory (path-get "target")
+                                             "test-crate-storage"
+                                             (into-array FileAttribute []))]
+    (testing "basic crate storage and cache hits"
+      (with-redefs [cache-root (delay (-> temp-path
+                                          .toAbsolutePath
+                                          (str "/my-cache1")))
+                    hsync/get (fn [url]
+                                {:status 200
+                                 :body (java.io.ByteArrayInputStream. (str-bytes "file contents"))})]
+
+        (is (false? (.exists (io/file @cache-root))))
+        (let [resp (cache-handler (mock/request :get "/api/v1/crates/hyper/0.8.0/hyper.crate"))]
+          (is (= 200 (:status resp)))
+          (is (= "file contents" (slurp (:body resp))))
+          (is (true? (.exists (io/file @cache-root))))
+          (is (true? (.exists (io/file (str @cache-root "/hyper/0.8.0/hyper.crate"))))))
+
+        ;; Rebinding the get function as it should be pulling from local cache, not re-downloading the crate
+        (with-redefs [hsync/get (fn [url]
+                                  (throw (RuntimeException. "Should retrieve from cache")))]
+          (let [resp (cache-handler (mock/request :get "/api/v1/crates/hyper/0.8.0/hyper.crate"))]
+            (is (= 200 (:status resp)))
+            (is (= "file contents" (slurp (:body resp))))))))
+
+    (testing "failures to download from crates.io"
+      (with-redefs [cache-root (delay (-> temp-path
+                                          .toAbsolutePath
+                                          (str "/my-cache2")))
+                    hsync/get (fn [url]
+                                {:status 404
+                                 :body (ByteArrayInputStream. (str-bytes "Not Found"))})]
+
+        (is (false? (.exists (io/file @cache-root))))
+        (let [resp (cache-handler (mock/request :get "/api/v1/crates/hyper/0.8.0/hyper.crate"))]
+          (is (= 404 (:status resp)))
+          (is (re-find #"Not Found" (:body resp))))))))

--- a/test/crates_caching_proxy/core_test.clj
+++ b/test/crates_caching_proxy/core_test.clj
@@ -1,0 +1,7 @@
+(ns crates-caching-proxy.core-test
+  (:require [clojure.test :refer :all]
+            [crates-caching-proxy.core :refer :all]))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))

--- a/test/puppetlabs/crates_caching_proxy/core_test.clj
+++ b/test/puppetlabs/crates_caching_proxy/core_test.clj
@@ -1,4 +1,4 @@
-(ns crates-caching-proxy.core-test
+(ns puppetlabs.crates-caching-proxy.core-test
   (:import [java.nio.file Files Paths Path]
            [java.nio.file.attribute FileAttribute]
            [java.io ByteArrayInputStream])


### PR DESCRIPTION
The code lazily stores crates from crates.io as they are requested. Storing them locally after retrieving them from the remote server. The cache directory and the port can be changed via environment variables and activity is logged to the logs directory using logback.
